### PR TITLE
Add the `deprecated: false` mappings

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -1,5 +1,178 @@
 [
   {
+    "global": "DS.Adapter",
+    "module": "@ember-data/adapter",
+    "export": "default",
+    "localName": "Adapter",
+    "deprecated": false
+  },
+  {
+    "global": "DS.BuildURLMixin",
+    "module": "@ember-data/adapter",
+    "export": "BuildURLMixin",
+    "deprecated": false
+  },
+  {
+    "global": "DS.AdapterError",
+    "module": "@ember-data/adapter/error",
+    "export": "default",
+    "localName": "AdapterError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.AbortError",
+    "module": "@ember-data/adapter/error",
+    "export": "AbortError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.ConflictError",
+    "module": "@ember-data/adapter/error",
+    "export": "ConflictError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.ForbiddenError",
+    "module": "@ember-data/adapter/error",
+    "export": "ForbiddenError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.InvalidError",
+    "module": "@ember-data/adapter/error",
+    "export": "InvalidError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.NotFoundError",
+    "module": "@ember-data/adapter/error",
+    "export": "NotFoundError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.ServerError",
+    "module": "@ember-data/adapter/error",
+    "export": "ServerError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.TimeoutError",
+    "module": "@ember-data/adapter/error",
+    "export": "TimeoutError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.UnauthorizedError",
+    "module": "@ember-data/adapter/error",
+    "export": "UnauthorizedError",
+    "deprecated": false
+  },
+  {
+    "global": "DS.errorsArrayToHash",
+    "module": "@ember-data/adapter/error",
+    "export": "errorsArrayToHash",
+    "deprecated": false
+  },
+  {
+    "global": "DS.errorsHashToArray",
+    "module": "@ember-data/adapter/error",
+    "export": "errorsHashToArray",
+    "deprecated": false
+  },
+  {
+    "global": "DS.JSONAPIAdapter",
+    "module": "@ember-data/adapter/json-api",
+    "export": "default",
+    "localName": "JSONAPIAdapter",
+    "deprecated": false
+  },
+  {
+    "global": "DS.RESTAdapter",
+    "module": "@ember-data/adapter/rest",
+    "export": "default",
+    "localName": "RESTAdapter",
+    "deprecated": false
+  },
+  {
+    "global": "DS.Model",
+    "module": "@ember-data/model",
+    "export": "default",
+    "localName": "Model",
+    "deprecated": false
+  },
+  {
+    "global": "DS.attr",
+    "module": "@ember-data/model",
+    "export": "attr",
+    "deprecated": false
+  },
+  {
+    "global": "DS.belongsTo",
+    "module": "@ember-data/model",
+    "export": "belongsTo",
+    "deprecated": false
+  },
+  {
+    "global": "DS.hasMany",
+    "module": "@ember-data/model",
+    "export": "hasMany",
+    "deprecated": false
+  },
+  {
+    "global": "DS.Serializer",
+    "module": "@ember-data/serializer",
+    "export": "default",
+    "localName": "Serializer",
+    "deprecated": false
+  },
+  {
+    "global": "DS.JSONSerializer",
+    "module": "@ember-data/serializer/json",
+    "export": "default",
+    "localName": "JSONSerializer",
+    "deprecated": false
+  },
+  {
+    "global": "DS.JSONAPISerializer",
+    "module": "@ember-data/serializer/json-api",
+    "export": "default",
+    "localName": "JSONAPISerializer",
+    "deprecated": false
+  },
+  {
+    "global": "DS.RESTSerializer",
+    "module": "@ember-data/serializer/rest",
+    "export": "default",
+    "localName": "RESTSerializer",
+    "deprecated": false
+  },
+  {
+    "global": "DS.EmbeddedRecordsMixin",
+    "module": "@ember-data/serializer/rest",
+    "export": "EmbeddedRecordsMixin",
+    "deprecated": false
+  },
+  {
+    "global": "DS.Transform",
+    "module": "@ember-data/serializer/transform",
+    "export": "default",
+    "localName": "Transform",
+    "deprecated": false
+  },
+  {
+    "global": "DS.Store",
+    "module": "@ember-data/store",
+    "export": "default",
+    "localName": "Store",
+    "deprecated": false
+  },
+  {
+    "global": "DS.normalizeModelName",
+    "module": "@ember-data/store",
+    "export": "normalizeModelName",
+    "deprecated": false
+  },
+  {
     "global": "DS.RecordData",
     "module": "ember-data/-private",
     "export": "RecordData",

--- a/tests/nested-default-exports.test.js
+++ b/tests/nested-default-exports.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const mappings = require('../mappings.json');
+
+describe('All default exports have a local name defined', () => {
+  for (let mapping of mappings) {
+    if (mapping.export === 'default' && !mapping.deprecated) {
+      test(mapping.module, () => {
+        expect(mapping.localName).toBeTruthy();
+      });
+    }
+  }
+});


### PR DESCRIPTION
Following discussion with @runspired I'm adding the `deprecated: false` mappings. They'll be needed in further steps (lint rules / codemod).

They were initially part of https://github.com/ember-data/ember-data-rfc395-data/pull/3. But I ended up removing them in a commit. This allows me to add the commit here in a revert.