### PR TITLE
chore: Update the scripts used to generate the README

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     node: true,
   },
   rules: {
-    'prettier/prettier': ['error', { singleQuote: true, trailingComma: 'es5' }],
+    'prettier/prettier': ['error'],
   },
   overrides: [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/scripts/generate-by-module-markdown-table.js
+++ b/scripts/generate-by-module-markdown-table.js
@@ -6,7 +6,7 @@ const { compare, generateImportForMapping } = require('./shared');
 function normalize(mapping) {
   return {
     mapping,
-    group: mapping.module.split('/', 2).join('/'),
+    group: mapping.replacement.module.split('/', 2).join('/'),
   };
 }
 
@@ -42,14 +42,14 @@ function buildTable(result, row) {
 }
 
 function sortByPackageAndExport([, , mappingA], [, , mappingB]) {
-  if (mappingA.module === mappingB.module) {
+  if (mappingA.replacement.module === mappingB.replacement.module) {
     // ensure default exports sort higher within a package
     let aExport = mappingA.export === 'default' ? '' : mappingA.export;
     let bExport = mappingB.export === 'default' ? '' : mappingB.export;
     return compare(aExport || '', bExport || '');
   }
 
-  return compare(mappingA.module, mappingB.module);
+  return compare(mappingA.replacement.module, mappingB.replacement.module);
 }
 
 function printTable(table) {
@@ -85,7 +85,6 @@ function print() {
 }
 
 let table = mappings
-  .filter(mapping => !mapping.deprecated)
   .map(normalize)
   .sort(sortByGroup)
   .reduce(buildTable, {});

--- a/scripts/generate-markdown-table.js
+++ b/scripts/generate-markdown-table.js
@@ -6,21 +6,18 @@ let helpers = require('./shared');
 let maxBefore = 0;
 let maxAfter = 0;
 
-let rows = mappings
-  .filter(it => !it.deprecated)
-  .sort(byGlobal)
-  .map(mapping => {
-    let before = mapping.global;
-    let after = helpers.generateImportForMapping(mapping);
+let rows = mappings.sort(byGlobal).map(mapping => {
+  let before = mapping.global;
+  let after = helpers.generateImportForMapping(mapping);
 
-    before = code(before);
-    after = code(after);
+  before = code(before);
+  after = code(after);
 
-    maxBefore = Math.max(maxBefore, before.length);
-    maxAfter = Math.max(maxAfter, after.length);
+  maxBefore = Math.max(maxBefore, before.length);
+  maxAfter = Math.max(maxAfter, after.length);
 
-    return [before, after];
-  });
+  return [before, after];
+});
 
 // Add headers to beginning of array
 rows.unshift(['---', '---']);

--- a/scripts/generate-package-list.js
+++ b/scripts/generate-package-list.js
@@ -18,7 +18,6 @@ function indent(value) {
 }
 
 mappings
-  .filter(mapping => !mapping.deprecated)
   .map(mapping => mapping.module)
   .filter(unique)
   .map(key => indent(key))

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function sortByModule(a, b) {
-  return compare(a.module, b.module);
+  return compare(a.replacement.module, b.replacement.module);
 }
 
 function compare(a, b) {
@@ -9,14 +9,12 @@ function compare(a, b) {
 }
 
 function generateImportForMapping(mapping) {
-  let afterPackage = mapping.module;
-  let afterExportName = mapping.export;
+  let afterPackage = mapping.replacement.module;
+  let afterExportName = mapping.replacement.export;
   let afterIdentifier = mapping.localName || mapping.export;
 
   if (afterExportName === 'default') {
     return `import ${afterIdentifier} from '${afterPackage}';`;
-  } else if (afterExportName !== afterIdentifier) {
-    return `import { ${afterExportName} as ${afterIdentifier} } from '${afterPackage}';`;
   } else {
     return `import { ${afterExportName} } from '${afterPackage}';`;
   }


### PR DESCRIPTION
Previously, tables were generated using the (soon removed) `deprecated: false` mappings.

(also, add a `.prettierrc.js` to ease prettier usage in IDEs)